### PR TITLE
keep aliveを無効化するオプションを追加します

### DIFF
--- a/cache_stnsd/config.go
+++ b/cache_stnsd/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Password         string            `toml:"password"`
 	SSLVerify        bool              `toml:"ssl_verify"`
 	HttpProxy        string            `toml:"http_proxy"`
+	HttpKeepalive    bool              `toml:"http_keepalive"`
 	RequestTimeout   int               `toml:"request_timeout"`
 	RequestRetry     int               `toml:"request_retry"`
 	RequestLocktime  int64             `toml:"request_locktime"`
@@ -40,6 +41,7 @@ func defaultConfig(config *Config) {
 	config.NegativeCacheTTL = 60
 	config.SSLVerify = true
 	config.Cache = true
+	config.HttpKeepalive = true
 	config.RequestTimeout = 10
 	config.RequestRetry = 3
 	config.RequestLocktime = 60

--- a/cache_stnsd/http.go
+++ b/cache_stnsd/http.go
@@ -47,7 +47,7 @@ func NewHttp(config *Config, cache *ttlcache.Cache, version string) (*Http, erro
 		Password:       config.Password,
 		SkipSSLVerify:  config.SSLVerify,
 		HttpProxy:      config.HttpProxy,
-		HttpKeepalive:  config.HTTPKEEPALIVE,
+		HttpKeepalive:  config.HttpKeepalive,
 		RequestTimeout: config.RequestTimeout,
 		RequestRetry:   config.RequestRetry,
 		HttpHeaders:    config.HttpHeaders,

--- a/cache_stnsd/http.go
+++ b/cache_stnsd/http.go
@@ -47,6 +47,7 @@ func NewHttp(config *Config, cache *ttlcache.Cache, version string) (*Http, erro
 		Password:       config.Password,
 		SkipSSLVerify:  config.SSLVerify,
 		HttpProxy:      config.HttpProxy,
+		HttpKeepalive:  config.HTTPKEEPALIVE,
 		RequestTimeout: config.RequestTimeout,
 		RequestRetry:   config.RequestRetry,
 		HttpHeaders:    config.HttpHeaders,


### PR DESCRIPTION
Transport.DisableKeepAlivesをconfigから設定値を取得可能にして設定変更を可能にします。

(クライアントライブラリの方にも合わせてPRを出しています)

https://github.com/STNS/libstns-go/pull/7