### PR TITLE
support almalinux9(rhel9 clone)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ rpm: source_for_rpm ## Packaging for RPM
 
 .PHONY: pkg
 
-SUPPORTOS=centos7 centos8 ubuntu18 ubuntu20 ubuntu22 debian10 debian11
+SUPPORTOS=centos7 centos8 almalinux9 ubuntu18 ubuntu20 ubuntu22 debian10 debian11
 pkg: ## Create some distribution packages
 	rm -rf builds && mkdir builds
 	for i in $(SUPPORTOS); do \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,18 @@
 version: '3'
 services:
+  cache_almalinux9:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.almalinux-9
+      args:
+        GO_VERSION: 1.18.2
+    volumes:
+      - .:/go/src/github.com/STNS/cache-stnsd
+      - ~/pkg:/go/pkg
+      - ~/src:/go/src
+    environment:
+      DIST: el9
+    command: make rpm
   cache_centos8:
     build:
       context: .

--- a/dockerfiles/Dockerfile.almalinux-9
+++ b/dockerfiles/Dockerfile.almalinux-9
@@ -1,0 +1,25 @@
+FROM almalinux:9
+
+
+ARG GO_VERSION
+RUN dnf install -y epel-release rpmdevtools make clang glibc gcc
+ENV FILE go$GO_VERSION.linux-amd64.tar.gz
+ENV URL https://storage.googleapis.com/golang/$FILE
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN ln -s /usr/local/go/bin/go /bin/go
+
+RUN set -eux &&\
+  dnf -y install git &&\
+  dnf -y clean all &&\
+  curl -OL $URL &&\
+	tar -C /usr/local -xzf $FILE &&\
+	rm $FILE &&\
+  mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+ADD . /go/src/github.com/STNS/cache-stnsd
+WORKDIR /go/src/github.com/STNS/cache-stnsd
+
+RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+RUN sed -i "s;%_build_name_fmt.*;%_build_name_fmt\t%%{ARCH}/%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.el9.rpm;" /usr/lib/rpm/macros


### PR DESCRIPTION
related https://github.com/STNS/libnss/pull/45

el9 というvariantでgithubからインストールしようとすると

libnss の依存する cache-stnsd が el8 までしかなく、ダウンロードに失敗するため、こちらにも el9なパッケージを github上に用意していただきたいです。
