### PR TITLE
ビルド(go.mod): Goのバージョンを1.24.0から1.25.5に更新

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/STNS/cache-stnsd
 
-go 1.24.0
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
SSIA